### PR TITLE
Offload building process to OJ judger

### DIFF
--- a/configure
+++ b/configure
@@ -7,9 +7,7 @@ set -e
 
 bash build.bash
 
-# Compile program
-cmake -B bin
-cmake --build bin -j 22
+mkdir -p bin
 
 clang -emit-llvm -fno-builtin-printf -fno-builtin-memcpy -fno-builtin-malloc -fno-builtin-strlen -O3 --target=riscv32 lib/builtin.c -S -o bin/builtin.ll
 llc --march=riscv32 -O3 -mattr=+m,+a bin/builtin.ll -opaque-pointers -o bin/builtin.s


### PR DESCRIPTION
-j 22 用了太多内存，导致 oom killer 把评测机干掉了